### PR TITLE
[FEAT] 아지트 없이도 파티 생성할 수 있도록 변경 - 나중에 연결할 수 있음

### DIFF
--- a/src/modules/party/dtos/party.res.dto.ts
+++ b/src/modules/party/dtos/party.res.dto.ts
@@ -1,4 +1,4 @@
-import { IsBoolean, IsNumber, IsObject, IsString } from "class-validator";
+import { IsBoolean, IsNumber, IsObject, IsOptional, IsString } from "class-validator";
 
 export class PartyHostDto {
   /**
@@ -80,8 +80,9 @@ export class PartyGetResDto {
   /**
    * @example "아지트 이름"
    */
+  @IsOptional()
   @IsString()
-  azitName!: string;
+  azitName!: string | null;
 
   /**
    * @example 5

--- a/src/modules/party/repository/party.repository.ts
+++ b/src/modules/party/repository/party.repository.ts
@@ -12,7 +12,7 @@ export class PartyRepository {
   }
 
   // 2. 파티 생성
-  async createParty(data: any, userId: number, azitId: number, tx?: any) {
+  async createParty(data: any, userId: number, azitId?: number | null, tx?: any) {
     const client = tx || prisma;
     const { positionIds, gameId, tierId, ...rest } = data;
     return client.partyPost.create({
@@ -24,7 +24,7 @@ export class PartyRepository {
         user: { connect: { id: userId } },
         game: { connect: { id: gameId } },
         tier: tierId ? { connect: { id: BigInt(tierId) } } : undefined,
-        azit: { connect: { id: azitId } },
+        azit: azitId ? { connect: { id: azitId } } : undefined,
       },
     });
   }

--- a/src/modules/party/service/party.service.ts
+++ b/src/modules/party/service/party.service.ts
@@ -20,46 +20,38 @@ export class PartyService {
     if (masterError) return masterError;
 
     // 1-2. 아지트 정보 검증 및 설정
-    let { azitId, azitName, azitIconUrl } = dto;
+    const { azitId } = dto;
+    let azitName: string | null = null;
+    let azitIconUrl: string | null = null;
     if (azitId) {
       const azit = await this.partyRepository.findAzitById(azitId);
       if (!azit) return notFound({ message: "아지트를 찾을 수 없습니다.", errorCode: PartyErrorCode.NOT_FOUND_AZIT });
       azitName = azit.azitName;
-      azitIconUrl = azit.imageUrl ?? undefined;
-    } else if (!azitName || !azitIconUrl) {
-      return notFound({ message: "아지트 이름과 아이콘 URL이 필요합니다.", errorCode: PartyErrorCode.NOT_FOUND_AZIT });
+      azitIconUrl = azit.imageUrl ?? null;
     }
 
-    // 1-3. 트랜잭션: 임시 아지트 및 파티 생성
-    const result = await prisma.$transaction(async (tx) => {
-      let currentAzitId = azitId;
-      if (!currentAzitId) {
-        const tempAzit = await this.partyRepository.createTempAzit(azitName!, azitIconUrl!, tx);
-        currentAzitId = Number(tempAzit.id);
-      }
-      const party = await this.partyRepository.createParty(dto, userId, Number(currentAzitId), tx);
-      return { party, currentAzitId };
-    });
+    // 1-3. 파티 생성
+    const party = await this.partyRepository.createParty(dto, userId, azitId ?? null);
 
-    if (!result?.party) {
+    if (!party) {
       return internalServerError({ message: "파티 생성에 실패했습니다.", errorCode: PartyErrorCode.INTERNAL_SERVER_ERROR });
     }
 
     // 1-4. 응답 DTO 반환
     return created({
-      partyId: Number(result.party.id),
-      userId: Number(result.party.userId),
-      gameId: Number(result.party.gameId),
-      title: result.party.title,
-      memo: result.party.memo,
-      recruitmentPeople: result.party.recruitmentPeople,
-      tierId: result.party.tierId ? Number(result.party.tierId) : null,
+      partyId: Number(party.id),
+      userId: Number(party.userId),
+      gameId: Number(party.gameId),
+      title: party.title,
+      memo: party.memo,
+      recruitmentPeople: party.recruitmentPeople,
+      tierId: party.tierId ? Number(party.tierId) : null,
       positionIds: dto.positionIds,
-      isMicUse: result.party.isMicUse,
-      azitId: Number(result.party.azitId),
+      isMicUse: party.isMicUse,
+      azitId: Number(party.azitId),
       azitName,
       azitIconUrl,
-      createdAt: result.party.createdAt,
+      createdAt: party.createdAt,
     } as PartyCreateResDto);
   }
 
@@ -161,7 +153,7 @@ export class PartyService {
       title: party.title,
       memo: party.memo,
       tierName: party.tier?.name || null,
-      azitName: party.azit.azitName,
+      azitName: party.azit?.azitName ?? null,
       participants: party.recruitmentPeople,
       currentParticipants: party.applications.length + 1,
       isMic: party.isMicUse,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

#23 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

파티 생성 시 아지트 트랜잭션 로직 제거하여
기존에 있는 아지트를 연결하는 것도 가능하고,
아지트 없이도 생성 가능하다. 이때 관련 azitName, azitId 등은 Null로 반환


## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 

파티 테스트 전체 통과
<img width="747" height="122" alt="image" src="https://github.com/user-attachments/assets/ba8ef8cf-5c9e-4710-9b91-748aa425b6b5" />

### 통과한 테스트 케이스
- 전화번호 중복 검증
- 8자 미만의 비밀번호 입력
- 이메일 형식 검증

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷

> 관련된 스크린샷이 있다면 여기에 첨부해주세요. (예 : 성공 응답 - 스웨거, 포스트맨 등)

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요