### PR TITLE
[FEATURE] chatRoomParticipation 관계 추가

### DIFF
--- a/prisma/migrations/20260201163100_add_chat_room_participation/migration.sql
+++ b/prisma/migrations/20260201163100_add_chat_room_participation/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE `chat_room_member` (
+    `member_id` BIGINT NOT NULL,
+    `room_id` BIGINT NOT NULL,
+    `role` ENUM('creator', 'participant') NOT NULL DEFAULT 'participant',
+    `participation_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`member_id`, `room_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `chat_room_member` ADD CONSTRAINT `chat_room_member_member_id_fkey` FOREIGN KEY (`member_id`) REFERENCES `azit_user`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `chat_room_member` ADD CONSTRAINT `chat_room_member_room_id_fkey` FOREIGN KEY (`room_id`) REFERENCES `chat_rooms`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -458,6 +458,7 @@ model AzitUser {
   user     User         @relation(fields: [userId], references: [id])
   azit     Azit         @relation(fields: [azitId], references: [id], onDelete: Cascade)
   scheduleParticipations AzitScheduleParticipation[]
+  chatRoomParticipation  ChatRoomParticipation[]
   chats    Chat[]
 
   @@map("azit_user")
@@ -505,8 +506,27 @@ model ChatRoom {
 
   azit      Azit         @relation(fields: [azitId], references: [id], onDelete: Cascade)
   chats     Chat[]
+  chatRoomParticipation  ChatRoomParticipation[]
 
   @@map("chat_rooms")
+}
+
+model ChatRoomParticipation {
+  memberId        BigInt        @map("member_id")
+  roomId          BigInt        @map("room_id")
+  role            ChatRoomRole  @default(PARTICIPANT)
+  participationAt DateTime      @default(now()) @map("participation_at")
+
+  member          AzitUser      @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  room            ChatRoom      @relation(fields: [roomId], references: [id], onDelete: Cascade)
+
+  @@id([memberId, roomId])
+  @@map("chat_room_member")
+}
+
+enum ChatRoomRole {
+  CREATOR     @map("creator")
+  PARTICIPANT @map("participant")
 }
 
 model Chat {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

#78 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

아지트유저 테이블과 챗룸 테이블 사이에 관계테이블을 만들어
비공개 채팅방 생성 시에 role에 따른 권한을 부여할 수 있고, 특정 아지트원만 초대할 수 있도록 함.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

지금 erdcloud가 수정 권한이 막혀있습니다. 그래서 사진을 첨부 못해서
직접 코드를 풀 받으셔서 수정 사항을 확인하시거나 테스트하시면 될 것 같습니다!