### PR TITLE
[FEATURE] TemperScore(TS) 계산 시스템 구현

### DIFF
--- a/prisma/migrations/20260203081957_add_feedback_ts_score_change/migration.sql
+++ b/prisma/migrations/20260203081957_add_feedback_ts_score_change/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `feedbacks` ADD COLUMN `ts_score_change` INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -637,18 +637,19 @@ model CommunityMedia {
 
 // 13. 피드백 관련 테이블
 model Feedback {
-  id          BigInt        @id @default(autoincrement())
-  userId      BigInt        @map("user_id")
-  targetId    BigInt        @map("target_id")
-  scheduleId  BigInt        @map("schedule_id")
-  content     String?       @db.Text
-  isBan       Boolean       @default(false) @map("is_ban")
-  createdAt   DateTime      @default(now()) @map("created_at")
-  updatedAt   DateTime      @default(now()) @updatedAt @map("updated_at")
-  user        User          @relation("FeedbackUser", fields: [userId], references: [id])
-  target      User          @relation("FeedbackTarget", fields: [targetId], references: [id])
-  schedule    AzitSchedule  @relation(fields: [scheduleId], references: [id])
-  
+  id             BigInt        @id @default(autoincrement())
+  userId         BigInt        @map("user_id")
+  targetId       BigInt        @map("target_id")
+  scheduleId     BigInt        @map("schedule_id")
+  content        String?       @db.Text
+  isBan          Boolean       @default(false) @map("is_ban")
+  tsScoreChange  Int           @default(0) @map("ts_score_change")
+  createdAt      DateTime      @default(now()) @map("created_at")
+  updatedAt      DateTime      @default(now()) @updatedAt @map("updated_at")
+  user           User          @relation("FeedbackUser", fields: [userId], references: [id])
+  target         User          @relation("FeedbackTarget", fields: [targetId], references: [id])
+  schedule       AzitSchedule  @relation(fields: [scheduleId], references: [id])
+
   positiveCategories FeedbackPositiveCategory[]
   negativeCategories FeedbackNegativeCategory[]
 

--- a/src/common/utils/temper-score.util.ts
+++ b/src/common/utils/temper-score.util.ts
@@ -36,12 +36,20 @@ export const PROTECTION_LOW = 60;
 // EMA 완충 계수 (감쇠 등 완만 반영용)
 export const EMA_ALPHA = 0.2;
 
-// 부정 카테고리 id → 감점. DB negative_categories·seed 순서와 매핑 (4개)
-export const NEGATIVE_PENALTIES: Record<number, number> = {
-  1: 15, // 과도한 욕설
-  2: 20, // 계정 도용 행위
-  3: 20, // 고의 트롤, 어뷰징
-  4: 25, // 핵, 치트 의심
+// 부정 카테고리 id. DB negative_categories.seed 순서와 매핑 (4개)
+export enum NegativeCategoryId {
+  ExcessiveProfanity = 1, // 과도한 욕설
+  AccountTheft = 2, // 계정 도용 행위
+  TrollingAbuse = 3, // 고의 트롤, 어뷰징
+  CheatSuspected = 4, // 핵, 치트 의심
+}
+
+// 부정 카테고리 id → 감점
+export const NEGATIVE_PENALTIES: Record<NegativeCategoryId, number> = {
+  [NegativeCategoryId.ExcessiveProfanity]: 15,
+  [NegativeCategoryId.AccountTheft]: 20,
+  [NegativeCategoryId.TrollingAbuse]: 20,
+  [NegativeCategoryId.CheatSuspected]: 25,
 };
 
 // W_diversity: 지금까지 target에게 칭찬한 고유 유저 수별 배수 (다양한 유저에게 받을수록 강화)
@@ -111,7 +119,9 @@ export function computePraiseScoreWithWeights(
 /** 부정 카테고리 중 제일 높은 감점 하나만 반영 */
 export function getMaxNegativePenalty(categoryIds: number[]): number {
   if (categoryIds.length === 0) return 0;
-  return Math.max(...categoryIds.map((id) => NEGATIVE_PENALTIES[id] ?? 15));
+  return Math.max(
+    ...categoryIds.map((id) => NEGATIVE_PENALTIES[id as NegativeCategoryId] ?? 15),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/common/utils/temper-score.util.ts
+++ b/src/common/utils/temper-score.util.ts
@@ -1,0 +1,160 @@
+/**
+ * TemperScore (TS) 계산 유틸
+ * - 신뢰·매너 점수 0~100, 시작값 60
+ * - 점수 올리기(칭찬): W_diversity, W_relation, W_time 적용 후 Feedback.tsScoreChange에 반영.
+ * - 점수 내리기(감점): Feedback.tsScoreChange 한 건 적용.
+ */
+
+// ---------------------------------------------------------------------------
+// 상수
+// ---------------------------------------------------------------------------
+
+// 피드백 점수 = Feedback.tsScoreChange (DB 필드, 기본값 0)
+export const FEEDBACK_TS_SCORE_CHANGE_DEFAULT = 0;
+
+export const TS_MIN = 0;
+export const TS_MAX = 100;
+export const TS_INITIAL = 60;
+
+// Zone 배수, 미구현: 상수만 두고 배수 적용은 추후 구현.
+export const ZONE_MULTIPLIER = {
+  normal: 1.0,
+  pro: 1.2,
+  temper: 1.5,
+} as const;
+
+// 일일 TS 변동 Clamp. 미적용: 오늘 누적 변동량 있을 때 상위(배치 등)에서 적용 예정.
+export const CLAMP_DAILY = 7;
+// 주간 TS 변동 Clamp
+export const CLAMP_WEEKLY = 20;
+
+// 보호구간: 이 점수 이상이면 변동 절반
+export const PROTECTION_HIGH = 95;
+// 보호구간: 이 점수 이하면 변동 절반
+export const PROTECTION_LOW = 60;
+
+// EMA 완충 계수 (감쇠 등 완만 반영용)
+export const EMA_ALPHA = 0.2;
+
+// 부정 카테고리 id → 감점. DB negative_categories·seed 순서와 매핑 (4개)
+export const NEGATIVE_PENALTIES: Record<number, number> = {
+  1: 15, // 과도한 욕설
+  2: 20, // 계정 도용 행위
+  3: 20, // 고의 트롤, 어뷰징
+  4: 25, // 핵, 치트 의심
+};
+
+// W_diversity: 지금까지 target에게 칭찬한 고유 유저 수별 배수 (다양한 유저에게 받을수록 강화)
+const W_DIVERSITY_TABLE: Record<number, number> = {
+  1: 1.0,
+  2: 1.2,
+  3: 1.35,
+};
+const W_DIVERSITY_4_OR_MORE = 1.5;
+
+// W_relation: 동일 유저가 이 target에게 N번째 칭찬 (반복 시 가중치 감소)
+const W_RELATION_TABLE: Record<number, number> = {
+  1: 1.0,
+  2: 0.9,
+  3: 0.75,
+};
+const W_RELATION_4_OR_MORE = 0.6;
+
+// W_time: 경기 종료 후 피드백 입력까지 경과 시간(분)
+const W_TIME_INVALID_MINUTES = 15; // 0~15분: 무효화 (감정/보복/담합 가능성)
+const W_TIME_NORMAL_MAX_MINUTES = 24 * 60; // 15분~24h: 1.0
+const W_TIME_LATE = 0.8; // 24h 이상: 0.8 (옵션)
+
+// ---------------------------------------------------------------------------
+// 칭찬 가중치 (점수 올릴 때만 사용)
+// ---------------------------------------------------------------------------
+
+/**
+ * W_diversity: 지금까지 target에게 칭찬한 고유 유저 수에 따른 배수
+ */
+export function getWDiversity(uniqueGiverCount: number): number {
+  if (uniqueGiverCount <= 0) return 0;
+  return W_DIVERSITY_TABLE[uniqueGiverCount] ?? W_DIVERSITY_4_OR_MORE;
+}
+
+/**
+ * W_relation: 동일 유저가 이 target에게 N번째로 남긴 칭찬 (1=첫번째)
+ */
+export function getWRelation(sameGiverCount: number): number {
+  if (sameGiverCount <= 0) return 0;
+  return W_RELATION_TABLE[sameGiverCount] ?? W_RELATION_4_OR_MORE;
+}
+
+/**
+ * W_time: 경기 종료 시각으로부터 피드백 입력까지 경과 분
+ * 0~15분: 0(무효), 15분~24h: 1.0, 24h~: 0.8
+ */
+export function getWTime(minutesSinceGameEnd: number): number {
+  if (minutesSinceGameEnd < W_TIME_INVALID_MINUTES) return 0;
+  if (minutesSinceGameEnd <= W_TIME_NORMAL_MAX_MINUTES) return 1.0;
+  return W_TIME_LATE;
+}
+
+/** 칭찬 한 건의 유효 점수 (W_relation × W_time × W_diversity) */
+export function computePraiseScoreWithWeights(
+  basePoints: number,
+  sameGiverCount: number,
+  minutesSinceGameEnd: number,
+  uniqueGiverCount: number,
+): number {
+  const wRelation = getWRelation(sameGiverCount);
+  const wTime = getWTime(minutesSinceGameEnd);
+  const wDiversity = getWDiversity(uniqueGiverCount);
+  return Math.round(basePoints * wRelation * wTime * wDiversity);
+}
+
+/** 부정 카테고리 중 제일 높은 감점 하나만 반영 */
+export function getMaxNegativePenalty(categoryIds: number[]): number {
+  if (categoryIds.length === 0) return 0;
+  return Math.max(...categoryIds.map((id) => NEGATIVE_PENALTIES[id] ?? 15));
+}
+
+// ---------------------------------------------------------------------------
+// 점수 올리기 / 내리기
+// ---------------------------------------------------------------------------
+
+/**
+ * 보호구간: 변동량 절반만 반영
+ * - 올라가는 경우 (delta > 0): 95점 이상일 때만 절반 반영
+ * - 내려가는 경우 (delta < 0): 60점 이하일 때만 절반 반영
+ */
+export function applyProtectionZone(currentTs: number, delta: number): number {
+  if (delta > 0 && currentTs >= PROTECTION_HIGH) {
+    // 올라가는 경우: 95점 이상일 때만 절반 반영
+    return delta * 0.5;
+  }
+  if (delta < 0 && currentTs <= PROTECTION_LOW) {
+    // 내려가는 경우: 60점 이하일 때만 절반 반영
+    return delta * 0.5;
+  }
+  return delta;
+}
+
+/**
+ * 피드백 한 건 반영 후 새 TS 계산 (Feedback.tsScoreChange 한 건)
+ * @param currentTs - 현재 TemperScore
+ * @param tsScoreChange - 변화량 (양수면 올라감, 음수면 내려감)
+ * @returns 0~100 범위의 새 TS (보호구간 적용)
+ */
+export function computeNewTemperScoreAfterFeedback(
+  currentTs: number,
+  tsScoreChange: number,
+  options: { applyProtection?: boolean } = {},
+): number {
+  const { applyProtection = true } = options;
+
+  let delta = tsScoreChange;
+  if (applyProtection) {
+    delta = applyProtectionZone(currentTs, delta);
+  }
+
+  let next = currentTs + delta;
+  if (next < TS_MIN) next = TS_MIN;
+  if (next > TS_MAX) next = TS_MAX;
+  return Math.round(next);
+}

--- a/src/modules/feedback/repositories/feedback.repository.ts
+++ b/src/modules/feedback/repositories/feedback.repository.ts
@@ -17,6 +17,7 @@ export class FeedbackRepository {
     scheduleId: bigint,
     content: string | null,
     isBan: boolean,
+    tsScoreChange: number,
     tx?: any,
   ): Promise<Feedback> {
     const client = tx || prisma;
@@ -27,6 +28,7 @@ export class FeedbackRepository {
         scheduleId,
         content,
         isBan,
+        tsScoreChange,
       },
     });
   }
@@ -74,7 +76,8 @@ export class FeedbackRepository {
 
     // 커서 존재할 때
     if (cursor) {
-      const { createdAt: cursorCreatedAt, feedbackId: cursorId } = parseFeedbackCursor(cursor);
+      const { createdAt: cursorCreatedAt, feedbackId: cursorId } =
+        parseFeedbackCursor(cursor);
 
       where.OR = [
         {
@@ -155,7 +158,7 @@ export class FeedbackRepository {
     userId: bigint, // 피드백을 작성할 사용자
   ): Promise<any[]> {
     const now = new Date();
-    
+
     // 사용자가 참여한 종료된 일정들의 참여자 조회
     const participants = await prisma.azitScheduleParticipation.findMany({
       where: {
@@ -241,5 +244,28 @@ export class FeedbackRepository {
     );
 
     return filteredParticipants;
+  }
+
+  /** 동일 유저가 target에게 남긴 긍정 피드백 건수 (W_relation용) */
+  async countWRelation(userId: bigint, targetId: bigint): Promise<number> {
+    return prisma.feedback.count({
+      where: {
+        userId,
+        targetId,
+        positiveCategories: { some: {} },
+      },
+    });
+  }
+
+  /** target에게 긍정 피드백을 남긴 고유 유저 수 (W_diversity용) */
+  async countWDiversity(targetId: bigint): Promise<number> {
+    const result = await prisma.feedback.groupBy({
+      by: ['userId'],
+      where: {
+        targetId,
+        positiveCategories: { some: {} },
+      },
+    });
+    return result.length;
   }
 }

--- a/src/modules/feedback/services/feedback.service.ts
+++ b/src/modules/feedback/services/feedback.service.ts
@@ -3,8 +3,19 @@ import { injectable, inject } from 'tsyringe';
 import { AzitScheduleParticipationRepository } from '../../azit/repositories/azit-schedule-participation.repository';
 import { AzitScheduleRepository } from '../../azit/repositories/azit-schedule.repository';
 import { UserRepository } from '../../user/user.repository';
+import {
+  computeNewTemperScoreAfterFeedback,
+  computePraiseScoreWithWeights,
+  getMaxNegativePenalty,
+} from '../../../common/utils/temper-score.util';
 import { FeedbackCreateReqDto } from '../dtos/feedback.req.dto';
-import { FeedbackCreateResDto, FeedbackListResDto, FeedbackResDto, FeedbackPendingListResDto, FeedbackPendingResDto } from '../dtos/feedback.res.dto';
+import {
+  FeedbackCreateResDto,
+  FeedbackListResDto,
+  FeedbackResDto,
+  FeedbackPendingListResDto,
+  FeedbackPendingResDto,
+} from '../dtos/feedback.res.dto';
 import { FeedbackCategoryRepository } from '../repositories/feedback-category.repository';
 import { FeedbackRepository } from '../repositories/feedback.repository';
 import { validateFeedbackCreation } from '../utils/feedback.validator';
@@ -55,6 +66,47 @@ export class FeedbackService {
       return validationResult;
     }
 
+    // DB에 저장할 순수 점수 (가중치 미적용)
+    let tsScoreChange = 0;
+    if (positiveCategoryIds.length > 0) {
+      tsScoreChange = 5; // 칭찬 기본 점수
+    }
+    if (negativeCategoryIds.length > 0) {
+      tsScoreChange -= getMaxNegativePenalty(negativeCategoryIds);
+    }
+
+    // TS 계산 시 가중치 적용을 위한 정보 수집 (칭찬인 경우만)
+    let wRelationData: {
+      sameGiverCount: number;
+      minutesSinceGameEnd: number;
+      uniqueGiverCount: number;
+    } | null = null;
+    if (positiveCategoryIds.length > 0) {
+      const schedule = await this.azitScheduleRepository.findScheduleById(
+        scheduleIdBigInt,
+      );
+      const now = new Date();
+      const minutesSinceGameEnd = schedule?.gameEndAt
+        ? Math.floor((now.getTime() - schedule.gameEndAt.getTime()) / 60_000)
+        : 24 * 60 + 1;
+      const prevPraiseCount = await this.feedbackRepository.countWRelation(
+        userId,
+        targetIdBigInt,
+      );
+      const sameGiverCount = prevPraiseCount + 1;
+      const prevUniqueGiverCount =
+        await this.feedbackRepository.countWDiversity(targetIdBigInt);
+      const hasGivenBefore = prevPraiseCount > 0;
+      const uniqueGiverCount = hasGivenBefore
+        ? prevUniqueGiverCount
+        : prevUniqueGiverCount + 1;
+      wRelationData = {
+        sameGiverCount,
+        minutesSinceGameEnd,
+        uniqueGiverCount,
+      };
+    }
+
     // 트랜잭션으로 묶어서 처리
     const result = await prisma.$transaction(async (tx) => {
       // 피드백 생성
@@ -64,6 +116,7 @@ export class FeedbackService {
         scheduleIdBigInt,
         content || null,
         isBan,
+        tsScoreChange,
         tx,
       );
 
@@ -87,6 +140,29 @@ export class FeedbackService {
 
       // isBan이 true일 때 차단 테이블에 추가
 
+      // target 유저 TS 갱신 (가중치 적용)
+      const currentTs = await this.userRepository.findTrustScoreById(
+        targetIdBigInt,
+        tx,
+      );
+      if (currentTs != null) {
+        // 칭찬인 경우 가중치 적용, 부정인 경우 순수 점수 그대로 사용
+        let effectiveTsChange = tsScoreChange;
+        if (positiveCategoryIds.length > 0 && wRelationData) {
+          effectiveTsChange = computePraiseScoreWithWeights(
+            tsScoreChange, // basePoints (5)
+            wRelationData.sameGiverCount,
+            wRelationData.minutesSinceGameEnd,
+            wRelationData.uniqueGiverCount,
+          );
+        }
+        const newTs = computeNewTemperScoreAfterFeedback(
+          currentTs,
+          effectiveTsChange,
+        );
+        await this.userRepository.updateTrustScore(targetIdBigInt, newTs, tx);
+      }
+
       return feedback;
     });
 
@@ -100,10 +176,13 @@ export class FeedbackService {
     cursor?: string,
     size: number = 15,
   ): Promise<Result<FeedbackListResDto>> {
-
     // 피드백 목록 조회
     const { feedbacks: feedbacksData, hasNext } =
-      await this.feedbackRepository.findFeedbacksByTargetIdWithCursor(userId, size, cursor);
+      await this.feedbackRepository.findFeedbacksByTargetIdWithCursor(
+        userId,
+        size,
+        cursor,
+      );
 
     // 응답 DTO 변환
     const feedbacks: FeedbackResDto[] = feedbacksData.map((feedback) =>
@@ -124,9 +203,8 @@ export class FeedbackService {
     userId: bigint,
   ): Promise<Result<FeedbackPendingListResDto>> {
     // 피드백 미완료 대상자 조회 (사용자가 참여한 모든 종료된 일정)
-    const participations = await this.feedbackRepository.findParticipantsWithoutFeedback(
-      userId,
-    );
+    const participations =
+      await this.feedbackRepository.findParticipantsWithoutFeedback(userId);
 
     // 응답 DTO 변환
     const targets: FeedbackPendingResDto[] = participations.map(

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -1,10 +1,9 @@
 // src/modules/user/user.repository.ts
-import { singleton } from "tsyringe";
-import { prisma } from "../../common/config/database"; 
+import { singleton } from 'tsyringe';
+import { prisma } from '../../common/config/database';
 
 @singleton()
-export class UserRepository{
-    
+export class UserRepository {
   async findByPhoneNumber(phone: string) {
     return prisma.user.findUnique({ where: { phone } });
   }
@@ -27,5 +26,26 @@ export class UserRepository{
 
   async deleteUser(id: number) {
     return prisma.user.delete({ where: { id } });
+  }
+
+  async findTrustScoreById(userId: bigint, tx?: any): Promise<number | null> {
+    const client = tx ?? prisma;
+    const user = await client.user.findUnique({
+      where: { id: userId },
+      select: { trustScore: true },
+    });
+    return user?.trustScore ?? null;
+  }
+
+  async updateTrustScore(
+    userId: bigint,
+    trustScore: number,
+    tx?: any,
+  ): Promise<void> {
+    const client = tx ?? prisma;
+    await client.user.update({
+      where: { id: userId },
+      data: { trustScore },
+    });
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #71

## #️⃣ 작업 내용

### 1. TS 계산 유틸리티 구현

#### TS 계산 로직 (`src/common/utils/temper-score.util.ts`)

- **가중치 함수 구현**
  - `getWDiversity`: 지금까지 target에게 칭찬한 고유 유저 수에 따른 배수
  - `getWRelation`: 동일 유저가 target에게 N번째로 남긴 칭찬에 따른 배수
  - `getWTime`: 경기 종료 시각으로부터 피드백 입력까지 경과 시간에 따른 배수
- **칭찬 점수 계산 함수**
  - `computePraiseScoreWithWeights`: W_relation × W_time × W_diversity 가중치를 적용한 칭찬 점수 계산
- **부정 카테고리 감점 함수**
  - `getMaxNegativePenalty`: 부정 카테고리 중 제일 높은 감점 하나만 반영
- **보호구간 로직**
  - `applyProtectionZone`: 올라가는 경우 고점수일 때만 절반 반영, 내려가는 경우 저점수일 때만 절반 반영
- **TS 계산 메인 함수**
  - `computeNewTemperScoreAfterFeedback`: 피드백 한 건 반영 후 새 TS 계산

### 2. TS 계산을 위한 Repository 메서드 추가

#### FeedbackRepository (`src/modules/feedback/repositories/feedback.repository.ts`)

- `countWRelation`: 동일 유저가 target에게 남긴 긍정 피드백 건수 조회 (W_relation 계산용)
- `countWDiversity`: target에게 긍정 피드백을 남긴 고유 유저 수 조회 (W_diversity 계산용)

#### UserRepository (`src/modules/user/user.repository.ts`)

- `findTrustScoreById`: 유저의 현재 TS 조회
- `updateTrustScore`: 유저의 TS 업데이트

### 3. Feedback 서비스에 TS 계산 로직 적용

#### FeedbackService (`src/modules/feedback/services/feedback.service.ts`)

- 피드백 생성 시 TS 계산 및 반영
  - DB에 순수 점수 저장 (칭찬 +5점 또는 부정 카테고리 최대 감점)
  - 칭찬인 경우 가중치 적용하여 TS 계산, 부정인 경우 순수 점수 그대로 사용
  - 트랜잭션 내에서 피드백 생성 및 target 유저 TS 업데이트

### 4. 데이터베이스 스키마 변경

- `Feedback` 테이블에 `tsScoreChange` 필드 추가
  - 피드백 한 건의 순수 TS 변화량 저장 (가중치 미적용)
  - 칭찬: +5, 부정: 최대 감점

## #️⃣ 테스트 결과

### 통과한 테스트 케이스

- 피드백 생성 시 `tsScoreChange` 필드에 순수 점수 저장 확인
- 피드백 생성 후 target 유저의 TS가 반영되는지 확인
- 부정 피드백 시 감점이 정상적으로 적용되는지 확인

### 미테스트 케이스

- 보호구간 로직 동작 (95점 이상 올라갈 때, 60점 이하 내려갈 때)
- 가중치 적용 (W_relation, W_time, W_diversity)

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷

> `feedbacks` 테이블에 `ts_score_change` 필드 추가
<img width="754" height="44" alt="image" src="https://github.com/user-attachments/assets/da8142bd-3e33-4af0-8294-0db2b1845d54" />

> 피드백 생성 후, TS 반영
<img width="180" height="76" alt="image" src="https://github.com/user-attachments/assets/e5709d79-6532-4716-8d60-e0743d427ac8" />


## #️⃣ 리뷰 요구사항 (선택)

### 1. DB 저장과 서비스 계산 분리 구조

- **DB 필드 추가**: `Feedback` 테이블에 `ts_score_change` 필드 추가
- **DB 저장**: `Feedback.tsScoreChange`에는 **순수 점수만 저장** (+5 또는 -점수, 가중치 미적용)
  <img width="434" height="167" alt="image" src="https://github.com/user-attachments/assets/32230ec1-33b1-4350-8660-5cc0945cf762" />
- **서비스 계산**: TS 반영 시 서비스 레이어에서 가중치 적용하여 실제 TS 계산 (피드백 생성할 때마다 즉각 반영)

### 2. 보호구간 로직

- 올라가는 경우: 95점 이상일 때만 절반 반영
- 내려가는 경우: 60점 이하일 때만 절반 반영

### 3. 미적용 항목

- **Clamp**: 현재는 실시간 피드백 저장 시에만 TS를 계산하므로 일일/주간 Clamp 구현 X
  <img width="332" height="25" alt="image" src="https://github.com/user-attachments/assets/d20af0b6-fc1f-47a0-b233-a8108df0e700" />

- **Zone**: Zone 배수(ZONE_MULTIPLIER)는 상수만 정의하고 **적용 X**
  <img width="766" height="158" alt="image" src="https://github.com/user-attachments/assets/1dc2be6d-cec2-4b2d-a79c-0e5b7abf8bc3" />


## 📎 참고 자료 (선택)

- [TemperScore (TS) 노션 문서](https://www.notion.so/Temper-score-TS-288ddc51f5c68066bcb2dfcf5960a3f8?source=copy_link)
