### PR TITLE
[FEATURE] refreshToken 발급

### DIFF
--- a/src/common/config/auth.ts
+++ b/src/common/config/auth.ts
@@ -1,9 +1,14 @@
 // src/common/config/auth.ts
 import "dotenv/config";
 
+/** Refresh token Redis TTL (초 단위). 기본 7일 */
+const REFRESH_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60;
+
 export const authConfig = {
   jwtSecret: process.env.JWT_SECRET || (() => { throw new Error("JWT_SECRET is missing!"); })(),
-  jwtExpiration: process.env.JWT_EXPIRATION || "2h", 
-  jwtAlgorithm: "HS256", 
+  jwtExpiration: process.env.JWT_EXPIRATION || "2h",
+  jwtRefreshExpiration: process.env.JWT_REFRESH_EXPIRATION || "7d",
+  jwtAlgorithm: "HS256",
   passwordSaltRounds: Number(process.env.PASSWORD_SALT_ROUNDS) || 10,
+  refreshTokenTTL: Number(process.env.REFRESH_TOKEN_TTL) || REFRESH_TOKEN_TTL_SECONDS,
 };

--- a/src/modules/auth/controller/auth.controller.ts
+++ b/src/modules/auth/controller/auth.controller.ts
@@ -1,9 +1,9 @@
 import { Controller, Post, Body, Route, SuccessResponse, Middlewares, Tags, Response } from "tsoa";
 import { injectable, inject } from "tsyringe";
 import { AuthService } from "../service/auth.service";
-import { SignUpReqDto, LoginReqDto, SendCertificationReqDto, VerifyCertificationReqDto, VerifiyDuplicateNicknameReqDto } from "../dtos/auth.req.dto";
-import { SignUpResDto, LoginResDto, SendCertificationResDto, VerifyCertificationResDto, VerifiyDuplicateNicknameResDto } from "../dtos/auth.res.dto"
-import { Result, BadRequestError, ConflictError, InternalServerError } from "../../../common/types/result.type";
+import { SignUpReqDto, LoginReqDto, SendCertificationReqDto, VerifyCertificationReqDto, VerifiyDuplicateNicknameReqDto, RefreshTokenReqDto } from "../dtos/auth.req.dto";
+import { SignUpResDto, LoginResDto, SendCertificationResDto, VerifyCertificationResDto, VerifiyDuplicateNicknameResDto, RefreshTokenResDto } from "../dtos/auth.res.dto"
+import { Result, BadRequestError, ConflictError, InternalServerError, UnauthorizedError } from "../../../common/types/result.type";
 import { validationMiddleware } from "../../../common/middlewares/validation";
 
 @injectable()
@@ -61,13 +61,29 @@ export class AuthController extends Controller {
   }
 
   @SuccessResponse("200", "OK")
-  @Response<BadRequestError>(400, "Bad Request") 
+  @Response<BadRequestError>(400, "Bad Request")
   @Response<ConflictError>(409, "Conflict")
   @Response<InternalServerError>(500, "Internal Server Error")
   @Middlewares(validationMiddleware(VerifiyDuplicateNicknameReqDto))
   @Post("/nickname/validate-duplicate")
   public async verifyDuplicateNickname(@Body() body: VerifiyDuplicateNicknameReqDto): Promise<Result<VerifiyDuplicateNicknameResDto>> {
     const result = await this.authService.verifyDuplicateNickname(body);
+    this.setStatus(result.statusCode);
+    return result;
+  }
+
+  /**
+   * 리프레시 토큰으로 액세스 토큰 재발급
+   * 리프레시 토큰이 유효하면 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.
+   */
+  @SuccessResponse("200", "OK")
+  @Response<BadRequestError>(400, "Bad Request")
+  @Response<UnauthorizedError>(401, "Unauthorized")
+  @Response<InternalServerError>(500, "Internal Server Error")
+  @Middlewares(validationMiddleware(RefreshTokenReqDto))
+  @Post("/refresh")
+  public async refresh(@Body() body: RefreshTokenReqDto): Promise<Result<RefreshTokenResDto>> {
+    const result = await this.authService.refresh(body);
     this.setStatus(result.statusCode);
     return result;
   }

--- a/src/modules/auth/dtos/auth.req.dto.ts
+++ b/src/modules/auth/dtos/auth.req.dto.ts
@@ -105,3 +105,12 @@ export class VerifiyDuplicateNicknameReqDto {
   @IsNotEmpty()
   nickname!: string;
 }
+
+export class RefreshTokenReqDto {
+  /**
+   * @example "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+   */
+  @IsString()
+  @IsNotEmpty({ message: "리프레시 토큰은 필수입니다." })
+  refreshToken!: string;
+}

--- a/src/modules/auth/dtos/auth.res.dto.ts
+++ b/src/modules/auth/dtos/auth.res.dto.ts
@@ -21,6 +21,23 @@ export class LoginResDto {
    * @example "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
    */
   accessToken!: string;
+
+  /**
+   * @example "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+   */
+  refreshToken!: string;
+}
+
+export class RefreshTokenResDto {
+  /**
+   * @example "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+   */
+  accessToken!: string;
+
+  /**
+   * @example "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+   */
+  refreshToken!: string;
 }
 
 export class SendCertificationResDto {

--- a/src/modules/auth/service/auth.service.ts
+++ b/src/modules/auth/service/auth.service.ts
@@ -2,8 +2,8 @@
 import { injectable, inject } from "tsyringe";
 import * as jose from "jose";
 import { UserRepository } from "../../user/user.repository";
-import { SignUpReqDto, LoginReqDto, SendCertificationReqDto, VerifyCertificationReqDto, VerifiyDuplicateNicknameReqDto} from "../dtos/auth.req.dto";
-import { SignUpResDto, LoginResDto, SendCertificationResDto, VerifyCertificationResDto, VerifiyDuplicateNicknameResDto } from "../dtos/auth.res.dto"
+import { SignUpReqDto, LoginReqDto, SendCertificationReqDto, VerifyCertificationReqDto, VerifiyDuplicateNicknameReqDto, RefreshTokenReqDto } from "../dtos/auth.req.dto";
+import { SignUpResDto, LoginResDto, SendCertificationResDto, VerifyCertificationResDto, VerifiyDuplicateNicknameResDto, RefreshTokenResDto } from "../dtos/auth.res.dto"
 import { Result, created, ok, unauthorized, conflict, isSuccess, badRequest, success} from "../../../common/types/result.type";
 import { ResultChain } from "../../../common/types/result.chain";
 import { sendVerificationSms } from "../../../common/utils/sms.util";
@@ -59,8 +59,8 @@ export class AuthService {
   async login(dto: LoginReqDto): Promise<Result<LoginResDto>> {
     return await ResultChain.of(dto)
       .flatThenAsync((dto) => this.comparePasswordStep(dto))
-      .flatThenAsync((user) => this.generateAccessTokenStep(user))
-      .flatThen((accessToken) => Promise.resolve(ok(this.toLoginResponse(accessToken))))
+      .flatThenAsync((user) => this.generateTokensStep(user))
+      .flatThen((tokens) => Promise.resolve(ok(this.toLoginResponse(tokens))))
       .getResult();
   }
 
@@ -78,7 +78,7 @@ export class AuthService {
   }
 
   private async generateAccessTokenStep(user: any): Promise<Result<string>> {
-    const accessToken = await new jose.SignJWT({ userId: user.id })
+    const accessToken = await new jose.SignJWT({ userId: user.id.toString() })
       .setProtectedHeader({ alg: authConfig.jwtAlgorithm })
       .setIssuedAt()
       .setExpirationTime(authConfig.jwtExpiration)
@@ -86,8 +86,79 @@ export class AuthService {
     return success(accessToken);
   }
 
-  private toLoginResponse(accessToken: string): LoginResDto {
-    return { accessToken };
+  private async generateRefreshTokenStep(user: any): Promise<Result<string>> {
+    const refreshToken = await new jose.SignJWT({ userId: user.id.toString() })
+      .setProtectedHeader({ alg: authConfig.jwtAlgorithm })
+      .setIssuedAt()
+      .setExpirationTime(authConfig.jwtRefreshExpiration)
+      .sign(this.SECRET);
+    return success(refreshToken);
+  }
+
+  private async storeRefreshTokenStep(userId: bigint, refreshToken: string): Promise<Result<boolean>> {
+    const key = `${REDIS_PREFIX.REFRESH_TOKEN}${userId}`;
+    await redisClient.set(key, refreshToken, { EX: authConfig.refreshTokenTTL });
+    return success(true);
+  }
+
+  private async generateTokensStep(user: any): Promise<Result<{ accessToken: string; refreshToken: string }>> {
+    const [accessResult, refreshResult] = await Promise.all([
+      this.generateAccessTokenStep(user),
+      this.generateRefreshTokenStep(user),
+    ]);
+    if (!isSuccess(accessResult)) return accessResult;
+    if (!isSuccess(refreshResult)) return refreshResult;
+
+    const storeResult = await this.storeRefreshTokenStep(user.id, refreshResult.data);
+    if (!isSuccess(storeResult)) return storeResult;
+
+    return success({ accessToken: accessResult.data, refreshToken: refreshResult.data });
+  }
+
+  private toLoginResponse(tokens: { accessToken: string; refreshToken: string }): LoginResDto {
+    return { accessToken: tokens.accessToken, refreshToken: tokens.refreshToken };
+  }
+
+  async refresh(dto: RefreshTokenReqDto): Promise<Result<RefreshTokenResDto>> {
+    return await ResultChain.of(dto)
+      .flatThenAsync((dto) => this.verifyRefreshTokenStep(dto.refreshToken))
+      .flatThenAsync((userId) => this.validateStoredRefreshTokenStep(userId, dto.refreshToken))
+      .flatThenAsync(async (userId) => {
+        const user = await this.userRepository.findById(Number(userId));
+        if (!user) return unauthorized({ message: "유저를 찾을 수 없습니다.", errorCode: "AUTH_REFRESH_FAILED" });
+        return success(user);
+      })
+      .flatThenAsync((user) => this.generateTokensStep(user))
+      .flatThenAsync((tokens) =>
+        Promise.resolve(ok<RefreshTokenResDto>({ accessToken: tokens.accessToken, refreshToken: tokens.refreshToken })),
+      )
+      .getResult();
+  }
+
+  private async verifyRefreshTokenStep(refreshToken: string): Promise<Result<bigint>> {
+    try {
+      const { payload } = await jose.jwtVerify(refreshToken, this.SECRET);
+      const userId = payload.userId;
+      if (userId === undefined || userId === null) {
+        return unauthorized({ message: "유효하지 않은 리프레시 토큰입니다.", errorCode: "AUTH_REFRESH_FAILED" });
+      }
+      const userIdStr = typeof userId === "number" ? String(userId) : typeof userId === "string" ? userId : null;
+      if (userIdStr === null) {
+        return unauthorized({ message: "유효하지 않은 리프레시 토큰입니다.", errorCode: "AUTH_REFRESH_FAILED" });
+      }
+      return success(BigInt(userIdStr));
+    } catch {
+      return unauthorized({ message: "만료되었거나 유효하지 않은 리프레시 토큰입니다.", errorCode: "AUTH_REFRESH_FAILED" });
+    }
+  }
+
+  private async validateStoredRefreshTokenStep(userId: bigint, refreshToken: string): Promise<Result<bigint>> {
+    const key = `${REDIS_PREFIX.REFRESH_TOKEN}${userId}`;
+    const storedToken = await redisClient.get(key);
+    if (!storedToken || storedToken !== refreshToken) {
+      return unauthorized({ message: "만료되었거나 유효하지 않은 리프레시 토큰입니다.", errorCode: "AUTH_REFRESH_FAILED" });
+    }
+    return success(userId);
   }
 
   async sendCertification(dto: SendCertificationReqDto): Promise<Result<SendCertificationResDto>> {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

#123 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

## refreshToken 재발급
<img width="1340" height="540" alt="image" src="https://github.com/user-attachments/assets/17d74236-44c7-47a6-a47c-18851179ba50" />

## Auth/Login -> accessToken과 refreshToken 둘다 반환
<img width="739" height="411" alt="image" src="https://github.com/user-attachments/assets/6ac46e3e-606e-4aff-a300-19eead9b7b7f" />

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

리프레시토큰은 만료 기한은 7일로 해두었습니다.
기존 auth/login에서 리프레시토큰도 같이 반환합니다.
/refresh는 refreshToken과 accessToken 재발급을 위해 호출하며 body로 refreshToken을 넘기면 됩니다.

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요