### PR TITLE
[FIX] 스케줄 목록 조회 시 작성자 식별 필드 추가

### DIFF
--- a/src/modules/azit/dtos/azit-schedule.res.dto.ts
+++ b/src/modules/azit/dtos/azit-schedule.res.dto.ts
@@ -138,6 +138,13 @@ export class AzitScheduleDetailResDto extends AzitScheduleResDto {
   is_participated!: boolean;
 
   /**
+   * 현재 사용자가 작성자인지 여부
+   * @example true
+   */
+  @IsBoolean()
+  is_creator!: boolean;
+
+  /**
    * 참여자 목록
    * @example []
    */
@@ -159,6 +166,7 @@ export class AzitScheduleDetailResDto extends AzitScheduleResDto {
       participations: any[];
     },
     isParticipated: boolean,
+    isCreator: boolean,
     participants: AzitScheduleParticipantResDto[],
   ): AzitScheduleDetailResDto {
     const base = AzitScheduleResDto.from(schedule);
@@ -166,6 +174,7 @@ export class AzitScheduleDetailResDto extends AzitScheduleResDto {
       ...base,
       current_participants: schedule.participations.length,
       is_participated: isParticipated,
+      is_creator: isCreator,
       participants: participants,
     };
   }

--- a/src/modules/azit/services/azit-schedule.service.ts
+++ b/src/modules/azit/services/azit-schedule.service.ts
@@ -128,9 +128,19 @@ export class AzitScheduleService {
     // 3. 사용자의 AzitUser ID 조회 (참여 여부 확인용)
     const azitUserId = memberCheckResult.data.id;
 
-    // 4. DTO 매핑
+    // 4. 각 스케줄의 작성자 여부 확인
+    const creatorChecks = await Promise.all(
+      schedules.map((schedule: any) =>
+        this.azitScheduleParticipationRepository.isScheduleCreator(
+          azitUserId,
+          schedule.id,
+        ),
+      ),
+    );
+
+    // 5. DTO 매핑
     const mappedSchedules: AzitScheduleDetailResDto[] = schedules.map(
-      (schedule: any) => {
+      (schedule: any, index: number) => {
         // 참여자 정보 매핑
         const participants: AzitScheduleParticipantResDto[] =
           schedule.participations.map((participation: any) =>
@@ -142,15 +152,19 @@ export class AzitScheduleService {
           (p: any) => p.memberId === azitUserId,
         );
 
+        // 사용자가 작성자인지 여부 확인
+        const isCreator = creatorChecks[index];
+
         return AzitScheduleDetailResDto.fromDetail(
           schedule,
           isParticipated,
+          isCreator,
           participants,
         );
       },
     );
 
-    // 5. 다음 커서 생성
+    // 6. 다음 커서 생성
     let nextCursor: string | null = null;
     if (hasNext && mappedSchedules.length > 0) {
       const lastSchedule = schedules[mappedSchedules.length - 1];


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #136 

## #️⃣ 작업 내용

- 스케줄 목록 조회 시 작성자 식별 필드 추가

## #️⃣ 테스트 결과

### 통과한 테스트 케이스
- 스케줄 목록 조회 시, 스케줄 작성자 식별 필드 같이 잘 반환됨

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷

> `is_creator` 필드 추가
<img width="515" height="696" alt="image" src="https://github.com/user-attachments/assets/4211df27-254d-43bb-a0ac-1ecc132c5022" />

## #️⃣ 리뷰 요구사항 (선택)

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요