### PR TITLE
[CHORE] 엔드포인트 호출 앞 /api 추가 및 CORS 허용 설정

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -20,30 +20,47 @@ import { upload } from "./common/config/multer";
 
 export const app = express();
 
-app.use(cors({
-  origin: [
-    'http://localhost:5173', // 1. 로컬 테스트 주소
-    'https://playproof-frontend-afyn.vercel.app', // 2. 현재 배포된 특정 주소 (끝에 / 제거)
-    /^https:\/\/playproof-frontend.*\.vercel\.app$/ // 3. 정규표현식 (따옴표 제거)
-  ],
-  credentials: true
-}));
+const allowedOrigins: Array<string | RegExp> = [
+  /^http:\/\/localhost:\d+$/, // 로컬 전체 포트 허용
+  /^https:\/\/playproof-frontend(?:[-a-z0-9]+)?\.vercel\.app$/i
+];
+
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin) return callback(null, true);
+
+      const isAllowed = allowedOrigins.some((allowed) =>
+        typeof allowed === "string" ? allowed === origin : allowed.test(origin)
+      );
+
+      return callback(null, isAllowed);
+    },
+    credentials: true
+  })
+);
 app.use(morgan("dev"));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-app.use(optionalAuthMiddleware);
 
 const asyncapiSpecPath = path.resolve(process.cwd(), "asyncapi.yaml");
 const asyncapiHtmlPath = path.resolve(process.cwd(), "public", "asyncapi.html");
 const swaggerDocument = "default" in swaggerJson ? (swaggerJson as any).default : swaggerJson;
+const swaggerDocumentWithBase = {
+  ...swaggerDocument,
+  servers: [{ url: "/api" }, ...(swaggerDocument.servers ?? [])]
+};
 
 // Swagger UI
-app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerDocumentWithBase));
 app.get("/asyncapi.yaml", (_req, res) => res.sendFile(asyncapiSpecPath));
 app.get("/async-docs", (_req, res) => res.sendFile(asyncapiHtmlPath));
 
 // TSOA Routes 등록 (커스텀 multer 사용)
-RegisterRoutes(app, { multer: upload });
+const apiRouter = express.Router();
+apiRouter.use(optionalAuthMiddleware);
+RegisterRoutes(apiRouter, { multer: upload });
+app.use("/api", apiRouter);
 
 // Global Error Handler (반드시 라우트 등록 뒤에!)
 app.use(globalErrorHandler);


### PR DESCRIPTION
## #️⃣ PR 제목 
> [CHORE] 엔드포인트 호출 앞 /api 추가 및 CORS 허용 설정

## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

- #145

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 

<img width="435" height="224" alt="image" src="https://github.com/user-attachments/assets/f858bf93-0cd5-43a1-a873-b1ae1fadf611" />

### 통과한 테스트 케이스
- 기존 엔드포인트에서 `/api` 를 앞에 붙이고 호출 시 성공

## #️⃣ 변경 사항 체크리스트

- [x] 메인 서버 파일(app.ts 등)에서 라우터 미들웨어 경로 수정 (/ -> /api)
- [x] 기존 컨트롤러 및 라우터 내부의 경로가 상대 경로로 잘 작동하는지 확인
- [x] API 문서 도구의 Base Path 업데이트